### PR TITLE
Use cl-lib functions instead of cl.el functions

### DIFF
--- a/sphinx-doc-tests.el
+++ b/sphinx-doc-tests.el
@@ -4,130 +4,130 @@
 
 
 (ert-deftest sphinx-doc-test-str->arg ()
-  (assert (equal (sphinx-doc-str->arg "email")
-                 (make-sphinx-doc-arg :name "email")))
-  (assert (equal (sphinx-doc-str->arg "domain='example.com'")
-                 (make-sphinx-doc-arg :name "domain" :default "'example.com'")))
-  (assert (equal (sphinx-doc-str->arg "domain=\"example.com\"")
-                 (make-sphinx-doc-arg :name "domain" :default "\"example.com\"")))
-  (assert (equal (sphinx-doc-str->arg "ignore = None")
-                 (make-sphinx-doc-arg :name "ignore" :default "None"))))
+  (cl-assert (equal (sphinx-doc-str->arg "email")
+                    (make-sphinx-doc-arg :name "email")))
+  (cl-assert (equal (sphinx-doc-str->arg "domain='example.com'")
+                    (make-sphinx-doc-arg :name "domain" :default "'example.com'")))
+  (cl-assert (equal (sphinx-doc-str->arg "domain=\"example.com\"")
+                    (make-sphinx-doc-arg :name "domain" :default "\"example.com\"")))
+  (cl-assert (equal (sphinx-doc-str->arg "ignore = None")
+                    (make-sphinx-doc-arg :name "ignore" :default "None"))))
 
 
 (ert-deftest sphinx-doc-test-fndef->doc ()
-  (assert (equal (sphinx-doc-fndef->doc
-                  (make-sphinx-doc-fndef :name "greet"
-                              :args (list (make-sphinx-doc-arg :name "name")
-                                          (make-sphinx-doc-arg :name "greeting" :default "'Hello'"))))
-                 (make-sphinx-doc-doc :fields (list (make-sphinx-doc-field :key "param" :arg "name")
-                                         (make-sphinx-doc-field :key "param" :arg "greeting")
-                                         (make-sphinx-doc-field :key "returns")
-                                         (make-sphinx-doc-field :key "rtype"))))))
+  (cl-assert (equal (sphinx-doc-fndef->doc
+                     (make-sphinx-doc-fndef :name "greet"
+                                            :args (list (make-sphinx-doc-arg :name "name")
+                                                        (make-sphinx-doc-arg :name "greeting" :default "'Hello'"))))
+                    (make-sphinx-doc-doc :fields (list (make-sphinx-doc-field :key "param" :arg "name")
+                                                       (make-sphinx-doc-field :key "param" :arg "greeting")
+                                                       (make-sphinx-doc-field :key "returns")
+                                                       (make-sphinx-doc-field :key "rtype"))))))
 
 
 (ert-deftest sphinx-doc-test-fun-args ()
-  (assert (equal (sphinx-doc-fun-args "") '()))
-  (assert (equal (sphinx-doc-fun-args "name")
-                 (list (make-sphinx-doc-arg :name "name"))))
-  (assert (equal (sphinx-doc-fun-args "name, email")
-                 (list (make-sphinx-doc-arg :name "name") (make-sphinx-doc-arg :name "email"))))
-  (assert (equal (sphinx-doc-fun-args "name,email")
-                 (list (make-sphinx-doc-arg :name "name") (make-sphinx-doc-arg :name "email"))))
-  (assert (equal (sphinx-doc-fun-args "name, email=None")
-                 (list (make-sphinx-doc-arg :name "name") (make-sphinx-doc-arg :name "email" :default "None"))))
-  (assert (equal (sphinx-doc-fun-args "name, city='Mumbai', editor=\"emacs\"")
-                 (list (make-sphinx-doc-arg :name "name")
-                       (make-sphinx-doc-arg :name "city" :default "'Mumbai'")
-                       (make-sphinx-doc-arg :name "editor" :default "\"emacs\""))))
-  (assert (equal (sphinx-doc-fun-args "self, name")
-                 (list (make-sphinx-doc-arg :name "name"))))
-  (assert (equal (sphinx-doc-fun-args "name, *args, **kwargs")
-                 (list (make-sphinx-doc-arg :name "name")))))
+  (cl-assert (equal (sphinx-doc-fun-args "") '()))
+  (cl-assert (equal (sphinx-doc-fun-args "name")
+                    (list (make-sphinx-doc-arg :name "name"))))
+  (cl-assert (equal (sphinx-doc-fun-args "name, email")
+                    (list (make-sphinx-doc-arg :name "name") (make-sphinx-doc-arg :name "email"))))
+  (cl-assert (equal (sphinx-doc-fun-args "name,email")
+                    (list (make-sphinx-doc-arg :name "name") (make-sphinx-doc-arg :name "email"))))
+  (cl-assert (equal (sphinx-doc-fun-args "name, email=None")
+                    (list (make-sphinx-doc-arg :name "name") (make-sphinx-doc-arg :name "email" :default "None"))))
+  (cl-assert (equal (sphinx-doc-fun-args "name, city='Mumbai', editor=\"emacs\"")
+                    (list (make-sphinx-doc-arg :name "name")
+                          (make-sphinx-doc-arg :name "city" :default "'Mumbai'")
+                          (make-sphinx-doc-arg :name "editor" :default "\"emacs\""))))
+  (cl-assert (equal (sphinx-doc-fun-args "self, name")
+                    (list (make-sphinx-doc-arg :name "name"))))
+  (cl-assert (equal (sphinx-doc-fun-args "name, *args, **kwargs")
+                    (list (make-sphinx-doc-arg :name "name")))))
 
 
 (ert-deftest sphinx-doc-test-field->str ()
-  (assert (string= (sphinx-doc-field->str (make-sphinx-doc-field :key "param" :arg "greeting"))
-                   ":param greeting: "))
-  (assert (string= (sphinx-doc-field->str (make-sphinx-doc-field :key "param"
-                                                      :type "str"
-                                                      :arg "greeting"))
-                   ":param str greeting: "))
-  (assert (string= (sphinx-doc-field->str (make-sphinx-doc-field :key "rtype"))
-                   ":rtype: ")))
+  (cl-assert (string= (sphinx-doc-field->str (make-sphinx-doc-field :key "param" :arg "greeting"))
+                      ":param greeting: "))
+  (cl-assert (string= (sphinx-doc-field->str (make-sphinx-doc-field :key "param"
+                                                                    :type "str"
+                                                                    :arg "greeting"))
+                      ":param str greeting: "))
+  (cl-assert (string= (sphinx-doc-field->str (make-sphinx-doc-field :key "rtype"))
+                      ":rtype: ")))
 
 
 (ert-deftest sphinx-doc-test-doc->str ()
   (let ((d1 [cl-struct-sphinx-doc-doc "FIXME! briefly describe function" nil nil
-                           ([cl-struct-sphinx-doc-field "param" nil "name" ""]
-                            [cl-struct-sphinx-doc-field "returns" nil nil ""]
-                            [cl-struct-sphinx-doc-field "rtype" nil nil ""])])
+                                      ([cl-struct-sphinx-doc-field "param" nil "name" ""]
+                                       [cl-struct-sphinx-doc-field "returns" nil nil ""]
+                                       [cl-struct-sphinx-doc-field "rtype" nil nil ""])])
         (d2 [cl-struct-sphinx-doc-doc "Just another function"
-                           "This is some text before the fields section."
-                           "This is some text after the fields section."
-                           ([cl-struct-sphinx-doc-field "param" nil "name" ""]
-                            [cl-struct-sphinx-doc-field "returns" nil nil "constant 42"]
-                            [cl-struct-sphinx-doc-field "rtype" nil nil "integer"])]))
-    (assert (string= (sphinx-doc-doc->str d1)
-                     "\"\"\"FIXME! briefly describe function\n\n:param name: \n:returns: \n:rtype: \n\n\"\"\""))
-    (assert (string= (sphinx-doc-doc->str d2)
-                     "\"\"\"Just another function\n\nThis is some text before the fields section.\n\n:param name: \n:returns: constant 42\n:rtype: integer\n\nThis is some text after the fields section.\n\n\"\"\""))))
+                                      "This is some text before the fields section."
+                                      "This is some text after the fields section."
+                                      ([cl-struct-sphinx-doc-field "param" nil "name" ""]
+                                       [cl-struct-sphinx-doc-field "returns" nil nil "constant 42"]
+                                       [cl-struct-sphinx-doc-field "rtype" nil nil "integer"])]))
+    (cl-assert (string= (sphinx-doc-doc->str d1)
+                        "\"\"\"FIXME! briefly describe function\n\n:param name: \n:returns: \n:rtype: \n\n\"\"\""))
+    (cl-assert (string= (sphinx-doc-doc->str d2)
+                        "\"\"\"Just another function\n\nThis is some text before the fields section.\n\n:param name: \n:returns: constant 42\n:rtype: integer\n\nThis is some text after the fields section.\n\n\"\"\""))))
 
 
 (ert-deftest sphinx-doc-test-parse ()
-  (assert (equal (sphinx-doc-parse "FIXME! briefly describe function\n\n    :param name: \n    :returns: constant 42\n    :rtype: integer\n\n    " 4)
-                 (make-sphinx-doc-doc :summary "FIXME! briefly describe function"
-                           :before-fields ""
-                           :after-fields ""
-                           :fields (list (make-sphinx-doc-field :key "param" :arg "name")
-                                         (make-sphinx-doc-field :key "returns" :desc "constant 42")
-                                         (make-sphinx-doc-field :key "rtype" :desc "integer"))))))
+  (cl-assert (equal (sphinx-doc-parse "FIXME! briefly describe function\n\n    :param name: \n    :returns: constant 42\n    :rtype: integer\n\n    " 4)
+                    (make-sphinx-doc-doc :summary "FIXME! briefly describe function"
+                                         :before-fields ""
+                                         :after-fields ""
+                                         :fields (list (make-sphinx-doc-field :key "param" :arg "name")
+                                                       (make-sphinx-doc-field :key "returns" :desc "constant 42")
+                                                       (make-sphinx-doc-field :key "rtype" :desc "integer"))))))
 
 
 (ert-deftest sphinx-doc-test-lines->paras ()
-  (assert (sphinx-doc-lines->paras
-           '("Send message to a recipient as per the priority"
-             ""
-             "This is before comment. "
-             ""
-             "This is also before the comment but a second para"
-             ""
-             ":param str sender: email address of the sender"
-             "                   this is the second line of sender param"
-             ":param str recipient: email address of the receiver"
-             ":param str message_body: message to send"
-             ":param int priority: priority"
-             ":returns: nothing"
-             ":rtype: None"
-             ""
-             "This is after comment" "" ""))
-          '(("Send message to a recipient as per the priority")
-            ("This is before comment. ")
-            ("This is also before the comment but a second para")
-            (":param str sender: email address of the sender"
-             "                   this is the second line of sender param"
-             ":param str recipient: email address of the receiver"
-             ":param str message_body: message to send"
-             ":param int priority: priority"
-             ":returns: nothing"
-             ":rtype: None")
-            ("This is after comment"))))
+  (cl-assert (sphinx-doc-lines->paras
+              '("Send message to a recipient as per the priority"
+                ""
+                "This is before comment. "
+                ""
+                "This is also before the comment but a second para"
+                ""
+                ":param str sender: email address of the sender"
+                "                   this is the second line of sender param"
+                ":param str recipient: email address of the receiver"
+                ":param str message_body: message to send"
+                ":param int priority: priority"
+                ":returns: nothing"
+                ":rtype: None"
+                ""
+                "This is after comment" "" ""))
+             '(("Send message to a recipient as per the priority")
+               ("This is before comment. ")
+               ("This is also before the comment but a second para")
+               (":param str sender: email address of the sender"
+                "                   this is the second line of sender param"
+                ":param str recipient: email address of the receiver"
+                ":param str message_body: message to send"
+                ":param int priority: priority"
+                ":returns: nothing"
+                ":rtype: None")
+               ("This is after comment"))))
 
 
 (ert-deftest sphinx-doc-test-parse-fields ()
-  (assert (sphinx-doc-parse-fields
-           '(":param str sender: email address of the sender"
-             "                   this is the second line of sender param"
-             ":param str recipient: email address of the receiver"
-             ":param str message_body: message to send"
-             ":param int priority: priority"
-             ":returns: "
-             ":rtype: None"))
-          ([cl-struct-sphinx-doc-field "param" "str" "sender" "email address of the sender\n                   this is the second line of sender param"]
-           [cl-struct-sphinx-doc-field "param" "str" "recipient" "email address of the receiver"]
-           [cl-struct-sphinx-doc-field "param" "str" "message_body" "message to send"]
-           [cl-struct-sphinx-doc-field "param" "int" "priority" "priority"]
-           [cl-struct-sphinx-doc-field "returns" nil nil nil]
-           [cl-struct-sphinx-doc-field "rtype" nil nil "None"])))
+  (cl-assert (sphinx-doc-parse-fields
+              '(":param str sender: email address of the sender"
+                "                   this is the second line of sender param"
+                ":param str recipient: email address of the receiver"
+                ":param str message_body: message to send"
+                ":param int priority: priority"
+                ":returns: "
+                ":rtype: None"))
+             ([cl-struct-sphinx-doc-field "param" "str" "sender" "email address of the sender\n                   this is the second line of sender param"]
+              [cl-struct-sphinx-doc-field "param" "str" "recipient" "email address of the receiver"]
+              [cl-struct-sphinx-doc-field "param" "str" "message_body" "message to send"]
+              [cl-struct-sphinx-doc-field "param" "int" "priority" "priority"]
+              [cl-struct-sphinx-doc-field "returns" nil nil nil]
+              [cl-struct-sphinx-doc-field "rtype" nil nil "None"])))
 
 
 (ert-deftest sphinx-doc-test-merge-fields ()
@@ -138,8 +138,8 @@
                [cl-struct-sphinx-doc-field "param" nil "age" ""]
                [cl-struct-sphinx-doc-field "returns" nil nil ""]
                [cl-struct-sphinx-doc-field "rtype" nil nil ""])))
-    (assert (equal (sphinx-doc-merge-fields fs1 fs2)
-                   (list (make-sphinx-doc-field :key "param" :arg "name" :type "str" :desc "This is name")
-                         (make-sphinx-doc-field :key "param" :arg "age" :desc "")
-                         (make-sphinx-doc-field :key "returns" :desc "constant 42")
-                         (make-sphinx-doc-field :key "rtype" :desc "integer"))))))
+    (cl-assert (equal (sphinx-doc-merge-fields fs1 fs2)
+                      (list (make-sphinx-doc-field :key "param" :arg "name" :type "str" :desc "This is name")
+                            (make-sphinx-doc-field :key "param" :arg "age" :desc "")
+                            (make-sphinx-doc-field :key "returns" :desc "constant 42")
+                            (make-sphinx-doc-field :key "rtype" :desc "integer"))))))

--- a/sphinx-doc.el
+++ b/sphinx-doc.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/naiquevin/sphinx-doc.el
 ;; Version: 0.2.0
 ;; Keywords: Sphinx, Python
-;; Package-Requires: ((s "1.9.0"))
+;; Package-Requires: ((s "1.9.0") (cl-lib "0.5"))
 
 ;; This program is *not* a part of emacs and is provided under the MIT
 ;; License (MIT) <http://opensource.org/licenses/MIT>
@@ -42,7 +42,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 (require 's)
 
 
@@ -240,14 +240,14 @@
    (mapcar
     #'reverse
     (car
-     (reduce (lambda (acc x)
-               (let ((paras (car acc))
-                     (prev-blank? (cdr acc)))
-                 (cond ((string= x "") (cons paras t))
-                       (prev-blank? (cons (cons (list x) paras) nil))
-                       (t (cons (cons (cons x (car paras)) (cdr paras)) nil)))))
-             (cdr lines)
-             :initial-value (cons (list (list (car lines))) nil))))))
+     (cl-reduce (lambda (acc x)
+                  (let ((paras (car acc))
+                        (prev-blank? (cdr acc)))
+                    (cond ((string= x "") (cons paras t))
+                          (prev-blank? (cons (cons (list x) paras) nil))
+                          (t (cons (cons (cons x (car paras)) (cdr paras)) nil)))))
+                (cdr lines)
+                :initial-value (cons (list (list (car lines))) nil))))))
 
 
 (defun sphinx-doc-parse-fields (fields-para)


### PR DESCRIPTION
Both cl-lib functions and cl.el functions are used in original
code, but we should use just one.
