### PR TITLE
Fix 'free variable' compiler warnings

### DIFF
--- a/sphinx-doc.el
+++ b/sphinx-doc.el
@@ -66,6 +66,7 @@
 (defconst sphinx-doc-raises-variants '("raises" "raise" "except" "exception"))
 (defconst sphinx-doc-returns-variants '("returns" "return"))
 
+(defvar sphinx-doc-python-indent)
 
 ;; struct definitions
 


### PR DESCRIPTION
Byte compiling sphinx-doc.el generates the following compiler warnings:

    In sphinx-doc:
    sphinx-doc.el:416:54:Warning: reference to free variable
        `sphinx-doc-python-indent'

    In sphinx-doc-mode:
    sphinx-doc.el:447:17:Warning: assignment to free variable
        `sphinx-doc-python-indent'

Defining `sphinx-doc-python-indent` silences the warnings.