### PR TITLE
Include arguments with asterik, fix issues with type hinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ file)
 This will enable the `sphinx-doc-mode` and bind the interactive
 function `sphinx-doc` to `C-c M-d`.
 
+If `(setq sphinx-doc-all-arguments t)` is added to `.emacs`, arguments
+that start with an asterisk are shown in the docstring, e.g. `*args` or
+`**kwargs`.
+
 
 Usage
 -----

--- a/sphinx-doc.el
+++ b/sphinx-doc.el
@@ -54,10 +54,10 @@
 
 ;; regular expression to identify a valid function definition in
 ;; python and match it's name and arguments
-(defconst sphinx-doc-fun-regex "^ *def \\([a-zA-Z0-9_]+\\)(\\(\\(?:.\\|\n\\)*\\))\\(\\| -> [a-zA-Z0-9_.]+\\):$")
+(defconst sphinx-doc-fun-regex "^ *def \\([a-zA-Z0-9_.]+\\)(\\(\\(?:.\\|\n\\)*\\))\\( -> [][a-zA-Z0-9_., ]*\\|\\):$")
 
 ;; regex for type hints for arguments
-(defconst sphinx-doc-fun-arg-hint-regex ": [a-zA-Z0-9_.]+")
+(defconst sphinx-doc-fun-arg-hint-regex ": [a-zA-Z0-9_.]+\\(\[[][a-zA-Z0-9_., ]*\]\\|\\)+")
 
 ;; regexes for beginning and end of python function definitions
 (defconst sphinx-doc-fun-beg-regex "def")
@@ -71,13 +71,21 @@
 
 (defvar sphinx-doc-python-indent)
 
+
 (defcustom sphinx-doc-all-arguments nil
-  "Defines, which arguments are documented in the docstring.
+  "Defines if all arguments are documented in the docstring.
 
 Default: nil
 
 If set to non-nil, arguments like *args and **kwargs are part of
 the docstring.  The argument \"self\" will always be omitted.")
+
+(defcustom sphinx-doc-exclude-rtype nil
+  "Defines if \"rtype\" is part of the docstring.
+
+Default: nil
+
+If set to non-nil, \"rtype\" will be excluded from the docstring.")
 
 
 ;; struct definitions
@@ -114,7 +122,7 @@ the docstring.  The argument \"self\" will always be omitted.")
 
 
 (cl-defstruct sphinx-doc-doc
-  (summary "FIXME! briefly describe function") ; summary line that fits on the first line
+  (summary "DESCRIBE FUNCTION HERE...") ; summary line that fits on the first line
   before-fields                                ; list of comments before fields
   after-fields                                 ; list of comments after fields
   fields)                                      ; list of field objects
@@ -138,8 +146,10 @@ the docstring.  The argument \"self\" will always be omitted.")
                        :key "param"
                        :arg (sphinx-doc-arg-name a)))
                     (sphinx-doc-fndef-args f))
-            (list (make-sphinx-doc-field :key "returns")
-                  (make-sphinx-doc-field :key "rtype")))))
+            (if sphinx-doc-exclude-rtype
+                (list (make-sphinx-doc-field :key "returns"))
+              (list (make-sphinx-doc-field :key "returns")
+                    (make-sphinx-doc-field :key "rtype"))))))
 
 
 (defun sphinx-doc-fun-args (argstrs)
@@ -153,12 +163,14 @@ sphinx-doc-all-arguments is nil."
                 (-filter
                  (lambda (str)
                    (and (not (string= (substring str 0 1) "*"))
+                        (not (string= str ""))
                         (not (string= str "self"))))
                  (mapcar #'s-trim
                          (split-string argstrs ",")))
               (-filter
                (lambda (str)
-                      (not (string= str "self")))
+                 (and (not (string= str ""))
+                      (not (string= str "self"))))
                (mapcar #'s-trim
                        (split-string argstrs ",")))))))
 

--- a/sphinx-doc.el
+++ b/sphinx-doc.el
@@ -265,12 +265,12 @@ and a blank line between each para."
   "Parse a single field into field object.
 Argument S represents a single field in the fields paragraph of
 the docstring."
-  (cond ((string-match "^:\\([a-z]+\\) \\([a-z.]+\\) \\([a-zA-Z0-9_]+\\):\s?\\(.*\\(?:\n\s*.*\\)*\\)$" s)
+  (cond ((string-match "^:\\([a-z]+\\) \\([a-z.]+\\) \\([a-zA-Z0-9_\*]+\\):\s?\\(.*\\(?:\n\s*.*\\)*\\)$" s)
          (make-sphinx-doc-field :key (match-string 1 s)
                                 :type (match-string 2 s)
                                 :arg (match-string 3 s)
                                 :desc (match-string 4 s)))
-        ((string-match "^:\\([a-z]+\\) \\([a-zA-Z0-9_]+\\):\s?\\(.*\\(?:\n\s*.*\\)*\\)$" s)
+        ((string-match "^:\\([a-z]+\\) \\([a-zA-Z0-9_\*]+\\):\s?\\(.*\\(?:\n\s*.*\\)*\\)$" s)
          (make-sphinx-doc-field :key (match-string 1 s)
                                 :arg (match-string 2 s)
                                 :desc (match-string 3 s)))

--- a/sphinx-doc.el
+++ b/sphinx-doc.el
@@ -54,11 +54,14 @@
 
 ;; regular expression to identify a valid function definition in
 ;; python and match it's name and arguments
-(defconst sphinx-doc-fun-regex "^ *def \\([a-zA-Z0-9_]+\\)(\\(\\(?:.\\|\n\\)*\\)):$")
+(defconst sphinx-doc-fun-regex "^ *def \\([a-zA-Z0-9_]+\\)(\\(\\(?:.\\|\n\\)*\\))\\(\\| -> [a-zA-Z0-9_.]+\\):$")
+
+;; regex for type hints for arguments
+(defconst sphinx-doc-fun-arg-hint-regex ": [a-zA-Z0-9_.]+")
 
 ;; regexes for beginning and end of python function definitions
 (defconst sphinx-doc-fun-beg-regex "def")
-(defconst sphinx-doc-fun-end-regex ":\\(?:\n\\)?")
+(defconst sphinx-doc-fun-end-regex ":[^ ]\\(?:\n\\)?")
 
 ;; Variations for some field keys recognized by Sphinx
 (defconst sphinx-doc-param-variants '("param" "parameter" "arg" "argument"
@@ -167,7 +170,9 @@ Returns nil if string is not a function definition."
   (when (string-match sphinx-doc-fun-regex s)
     (make-sphinx-doc-fndef
      :name (match-string 1 s)
-     :args (sphinx-doc-fun-args (match-string 2 s)))))
+     :args (sphinx-doc-fun-args
+            (replace-regexp-in-string
+             sphinx-doc-fun-arg-hint-regex "" (match-string 2 s))))))
 
 
 (defun sphinx-doc-field->str (f)

--- a/sphinx-doc.el
+++ b/sphinx-doc.el
@@ -57,7 +57,7 @@
 (defconst sphinx-doc-fun-regex "^ *def \\([a-zA-Z0-9_.]+\\)(\\(\\(?:.\\|\n\\)*\\))\\( -> [][a-zA-Z0-9_., ]*\\|\\):$")
 
 ;; regex for type hints for arguments
-(defconst sphinx-doc-fun-arg-hint-regex ": [a-zA-Z0-9_.]+\\(\[[][a-zA-Z0-9_., ]*\]\\|\\)+")
+(defconst sphinx-doc-fun-arg-hint-regex ": [a-zA-Z0-9_.]*\\([[][][a-zA-Z0-9_., ]*[]]\\|\\)")
 
 ;; regexes for beginning and end of python function definitions
 (defconst sphinx-doc-fun-beg-regex "def")
@@ -138,7 +138,9 @@ If set to non-nil, \"rtype\" will be excluded from the docstring.")
 
 
 (defun sphinx-doc-fndef->doc (f)
-  "Build a doc object solely from fndef F."
+  "Build a doc object solely from fndef F.
+Note that the key \"rtype\" is included if
+sphinx-doc-exclude-rtype is not nil."
   (make-sphinx-doc-doc
    :fields (append
             (mapcar (lambda (a)

--- a/sphinx-doc.el
+++ b/sphinx-doc.el
@@ -68,6 +68,15 @@
 
 (defvar sphinx-doc-python-indent)
 
+(defcustom sphinx-doc-all-arguments nil
+  "Defines, which arguments are documented in the docstring.
+
+Default: nil
+
+If set to non-nil, arguments like *args and **kwargs are part of
+the docstring.  The argument \"self\" will always be omitted.")
+
+
 ;; struct definitions
 
 (cl-defstruct sphinx-doc-arg
@@ -133,15 +142,22 @@
 (defun sphinx-doc-fun-args (argstrs)
   "Extract list of arg objects from string ARGSTRS.
 ARGSTRS is the string representing function definition in Python.
-Note that the arguments self, *args and **kwargs are ignored."
+Note that the arguments self, *args and **kwargs are ignored if
+sphinx-doc-all-arguments is nil."
   (when (not (string= argstrs ""))
     (mapcar #'sphinx-doc-str->arg
-            (-filter
-             (lambda (str)
-               (and (not (string= (substring str 0 1) "*"))
-                    (not (string= str "self"))))
-             (mapcar #'s-trim
-                     (split-string argstrs ","))))))
+            (if (not sphinx-doc-all-arguments)
+                (-filter
+                 (lambda (str)
+                   (and (not (string= (substring str 0 1) "*"))
+                        (not (string= str "self"))))
+                 (mapcar #'s-trim
+                         (split-string argstrs ",")))
+              (-filter
+               (lambda (str)
+                      (not (string= str "self")))
+               (mapcar #'s-trim
+                       (split-string argstrs ",")))))))
 
 
 (defun sphinx-doc-str->fndef (s)


### PR DESCRIPTION
I added a variable that toggles the inclusion of arguments with an asterik, like `*args` or `**kwargs`.

At the moment, type hinting breaks the `sphinx-doc` function. I modified the regex strings to make them ignore hints while still giving the expected output. 