### PR TITLE
Modified test running script for Linux compatibility

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,7 +9,11 @@ else
 fi
 
 function elpa_dep_dir() {
-    echo $(find ~/.emacs.d/elpa -type d -depth 1 | grep -E "/$1-\d+\.\d+" | sort -r | head -n 1)
+    if [[ $(uname -s) == "Darwin" ]]; then
+	echo $(find ~/.emacs.d/elpa -type d -depth 1 | grep -E "/$1-\d+\.\d+" | sort -r | head -n 1)
+    else
+	echo $(find ~/.emacs.d/elpa -maxdepth 1 -type d | grep -E "/$1-[0-9]+\.[0-9]+" | sort -r | head -n 1)
+    fi
 }
 
 $EMACS_BIN -batch \


### PR DESCRIPTION
Hi ! I was trying to work on adding types hint compatibility for sphinx-doc (thanks for the package btw !). This is still a work in progress but in the meanwhile, I encountered some errors while trying to run tests on my Linux machine. These came from the "elpa_dep_dir" function.

I had to search a little, but I found out there are differences between : 
- GNU find and BSD find. The synonym for "depth" option in a BSD find is "maxdepth" in GNU find (depth is a different option altogether)
- GNU grep and BSD grep. It seems they do not use the same regex syntax (GNU find uses pcre)

As a fix, I added an OS check in the function, and added a GNU compliant version when MacOS is not used.