### PR TITLE
tolerate square brackets in return type annotations

### DIFF
--- a/sphinx-doc-tests.el
+++ b/sphinx-doc-tests.el
@@ -264,4 +264,11 @@
             :name "fun"
             :args (list (make-sphinx-doc-arg :name "a")
                         (make-sphinx-doc-arg :name "b" :type "Union[str, list]")))))
+
+  (should (equal
+           (sphinx-doc-str->fndef "def fun(a, b) -> Optional[str]:")
+           (make-sphinx-doc-fndef
+            :name "fun"
+            :args (list (make-sphinx-doc-arg :name "a")
+                        (make-sphinx-doc-arg :name "b")))))
   )

--- a/sphinx-doc.el
+++ b/sphinx-doc.el
@@ -56,7 +56,7 @@
 ;; python and match it's name and arguments.
 (let ((fname-regex "\\([a-zA-Z0-9_]+\\)")
       (args-regex "(\\(\\(?:.\\|\n\\)*\\))")
-      (return-type-regex "\\(?: -> \\([a-zA-Z0-9\\.]*\\)\\)?"))
+      (return-type-regex "\\(?: -> \\([][a-zA-Z0-9\\.]*\\)\\)?"))
   (defconst sphinx-doc-fun-regex
     (format "^ *def %1$s%2$s%3$s:$"
             fname-regex


### PR DESCRIPTION
Currently, sphinx-doc does not create docstrings when return type annotations contain square brackets.

Example:
```python
from typing import Optional


def test(a, b) -> Optional[str]:
    if a == b:
        return "foo"
    else:
        return None
```

Steps to reproduce:
1. Create the example file as specified above.
2. Move the point into the body of the function.
3. Run `M-x sphinx-doc RET`.

Expected results:
A docstring should appear.

Actual results:
The buffer is unchanged and the following message is logged: `Failed to parse function definition ’def test(a, b) -> Optional[str]:’.`

This PR modifies the return type regex to tolerate square brackets in return type annotations and adds a corresponding test.